### PR TITLE
Update MessageAdapterItemClickListener.java

### DIFF
--- a/kf5sdk-master-v2/kf5sdkModule/src/main/java/com/kf5/sdk/im/adapter/listener/MessageAdapterItemClickListener.java
+++ b/kf5sdk-master-v2/kf5sdkModule/src/main/java/com/kf5/sdk/im/adapter/listener/MessageAdapterItemClickListener.java
@@ -34,8 +34,8 @@ public class MessageAdapterItemClickListener implements View.OnClickListener {
         try {
             Upload upload = imMessage.getUpload();
             String url = upload.getUrl();
-            File localFile = new File(FilePath.SAVE_RECORDER + MD5Utils.GetMD5Code(url) + ".amr");
-            if (localFile.exists()) {
+            File urlCacheFile = TextUtils.isEmpty(url) ? null : new File(FilePath.SAVE_RECORDER + MD5Utils.GetMD5Code(url) + ".amr");
+            if (urlCacheFile != null && urlCacheFile.exists()) {
                 VoicePlayListener.getInstance().startPlay(localFile.getAbsolutePath());
             } else {
                 File file = new File(FilePath.SAVE_RECORDER + upload.getName());


### PR DESCRIPTION
如果url为空的时候localFile会变成"/xxxx/.amr",此时如果缓存目录恰好真的有".arm"文件,就会播放错误的媒体文件.
所以优先判断url是否有效.另外至于为什么有的手机上真的生成了".arm"文件,目前没有分析.